### PR TITLE
Validate required CSV fields

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -5,14 +5,25 @@ from pathlib import Path
 from typing import Iterable
 
 
-def load_csv(path: str | Path) -> list[dict[str, str]]:
-    """Load a CSV file into a list of dictionaries."""
+def load_csv(path: str | Path, required_fields: Iterable[str] | None = None) -> list[dict[str, str]]:
+    """Load a CSV file into a list of dictionaries.
+
+    Args:
+        path: CSV file path.
+        required_fields: Optional field names that must exist in the header.
+    """
     csv_path = Path(path)
     if not csv_path.exists():
         raise FileNotFoundError(f"CSV file not found: {csv_path}")
 
     with csv_path.open(newline="", encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
+        fieldnames = set(reader.fieldnames or [])
+        if required_fields:
+            missing = sorted(set(required_fields) - fieldnames)
+            if missing:
+                raise ValueError(f"CSV file missing required fields: {', '.join(missing)}")
+
         return [dict(row) for row in reader]
 
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,27 @@
+import pytest
+
+from src.data_loader import load_csv
+
+
+def test_load_csv_validates_required_fields(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("name,score\nAda,10\n", encoding="utf-8")
+
+    rows = load_csv(csv_path, required_fields=["name", "score"])
+
+    assert rows == [{"name": "Ada", "score": "10"}]
+
+
+def test_load_csv_reports_missing_required_fields(tmp_path):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("name\nAda\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="score"):
+        load_csv(csv_path, required_fields=["name", "score"])
+
+
+def test_load_csv_reports_missing_file(tmp_path):
+    missing_path = tmp_path / "missing.csv"
+
+    with pytest.raises(FileNotFoundError, match="CSV file not found"):
+        load_csv(missing_path)


### PR DESCRIPTION
## Summary

Adds optional required-field validation to the CSV loader and tests the malformed-file cases.

## Changes

- Extend load_csv with backwards-compatible required_fields support
- Raise clear ValueError messages when required headers are missing
- Add tests for valid required fields, missing required fields, and missing files

## Related Issue

Closes #17

## Testing

- [x] Unit tests: python -m pytest
- [ ] Integration tests
- [ ] Manual verification
- [ ] Documentation verification

## Impact

Data-loading failures now happen early with actionable messages instead of letting malformed CSV files silently flow into downstream analysis.

## Breaking Changes

None. Existing load_csv(path) calls remain compatible.
