### PR TITLE
Handle rare classes when splitting processed data

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,8 @@
-from .orchestration import run_pipeline
-
 __all__ = ["run_pipeline"]
+
+
+def run_pipeline(*args, **kwargs):
+    """Run the ML pipeline, importing orchestration dependencies lazily."""
+    from .orchestration import run_pipeline as _run_pipeline
+
+    return _run_pipeline(*args, **kwargs)

--- a/src/preprocessing/preprocess.py
+++ b/src/preprocessing/preprocess.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Tuple
 
-import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from sklearn.impute import SimpleImputer
 from sklearn.model_selection import train_test_split
+from sklearn.impute import SimpleImputer
 from sklearn.preprocessing import StandardScaler
 
 
-def _load_raw(raw_path: Path) -> dd.DataFrame:
+def _load_raw(raw_path: Path):
+    import dask.dataframe as dd
+
     return dd.read_parquet(raw_path)
 
 
@@ -54,6 +55,16 @@ def preprocess_data(raw_path: Path, config: Dict, paths: Dict, logger) -> Path:
     return processed_path
 
 
+def _stratify_target(y: np.ndarray) -> np.ndarray | None:
+    """Return y for stratified splitting only when every class can be split."""
+    unique_values, counts = np.unique(y, return_counts=True)
+    if len(unique_values) <= 1:
+        return None
+    if counts.min() < 2:
+        return None
+    return y
+
+
 def split_data(processed_path: Path, config: Dict) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Split processed data into train and test sets."""
     df = pd.read_parquet(processed_path)
@@ -65,8 +76,8 @@ def split_data(processed_path: Path, config: Dict) -> Tuple[np.ndarray, np.ndarr
     X = df.drop(columns=["target"]).to_numpy()
     y = df["target"].to_numpy()
 
-    # Use stratify only if it makes sense (for classification with balanced classes)
-    stratify_param = y if len(np.unique(y)) > 1 else None
+    # Use stratify only when every class has enough observations to be split.
+    stratify_param = _stratify_target(y)
     
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, 

--- a/tests/test_preprocess_split.py
+++ b/tests/test_preprocess_split.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pandas as pd
+
+from src.preprocessing.preprocess import _stratify_target, split_data
+
+
+def test_stratify_target_skips_single_sample_class():
+    y = pd.Series([0, 0, 0, 1]).to_numpy()
+
+    assert _stratify_target(y) is None
+
+
+def test_stratify_target_keeps_balanced_classes():
+    y = pd.Series([0, 0, 1, 1]).to_numpy()
+
+    assert _stratify_target(y) is y
+
+
+def test_split_data_handles_rare_class_without_stratify(tmp_path: Path):
+    processed_path = tmp_path / "processed.parquet"
+    df = pd.DataFrame(
+        {
+            "feature_0": [1.0, 2.0, 3.0, 4.0],
+            "feature_1": [0.1, 0.2, 0.3, 0.4],
+            "target": [0, 0, 0, 1],
+        }
+    )
+    df.to_parquet(processed_path, index=False)
+
+    X_train, X_test, y_train, y_test = split_data(
+        processed_path,
+        {"test_size": 0.25, "random_state": 7},
+    )
+
+    assert len(X_train) == 3
+    assert len(X_test) == 1
+    assert len(y_train) == 3
+    assert len(y_test) == 1


### PR DESCRIPTION
## Summary
- add a stratification guard for processed train/test splits
- fall back to an unstratified split when a class has fewer than two samples
- keep balanced multiclass targets eligible for stratification
- lazy-load optional pipeline dependencies so preprocessing helpers can be imported independently

## Changes
- Added _stratify_target helper
- Updated split_data to use the helper
- Added rare-class regression tests
- Deferred Dask imports until pipeline/raw parquet loading is needed

## Testing
- python -m pytest tests/test_preprocess_split.py
- python -m pytest attempted, but local environment is missing dask.distributed required by 	ests/test_pipeline.py

## Related Issue
Closes #29

## Breaking Changes
None. Rare-class datasets now fall back to a valid non-stratified split instead of failing.