### PR TITLE
Make training random state configurable

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -28,6 +28,7 @@ preprocessing:
 
 training:
   model_type: random_forest
+  random_state: 42
   hyperparameters:
     n_estimators: [150, 250]
     max_depth: [5, 10, null]

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -11,7 +11,10 @@ from sklearn.model_selection import GridSearchCV, learning_curve
 
 
 def _build_model(config: Dict) -> Tuple[RandomForestClassifier, Dict]:
-    estimator = RandomForestClassifier(random_state=42, n_jobs=config.get("n_jobs", -1))
+    estimator = RandomForestClassifier(
+        random_state=config.get("random_state", 42),
+        n_jobs=config.get("n_jobs", -1),
+    )
     param_grid = config.get(
         "hyperparameters",
         {"n_estimators": [150, 250], "max_depth": [5, 10, None], "min_samples_split": [2, 4]},

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+
+TRAINER_PATH = Path(__file__).resolve().parents[1] / "src" / "training" / "trainer.py"
+spec = importlib.util.spec_from_file_location("trainer", TRAINER_PATH)
+trainer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(trainer)
+
+
+def test_build_model_uses_configured_random_state():
+    estimator, _ = trainer._build_model({"random_state": 123, "n_jobs": 1})
+
+    assert estimator.random_state == 123
+    assert estimator.n_jobs == 1
+
+
+def test_build_model_defaults_random_state_for_reproducibility():
+    estimator, _ = trainer._build_model({})
+
+    assert estimator.random_state == 42


### PR DESCRIPTION
## Summary
- use 	raining.random_state when building the random forest estimator
- add the training random state to the default config
- add focused regression coverage for configured and default seeds

## Changes
- Updated src/training/trainer.py
- Updated configs/config.yaml
- Added 	ests/test_training_config.py

## Testing
- python -m pytest tests/test_training_config.py
- python -m py_compile src/training/trainer.py tests/test_training_config.py

## Related Issue
Closes #25

## Breaking Changes
None. The default remains 42 when no training random state is configured.